### PR TITLE
Sbt support for building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+src/**/target
+project/target/
+target

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,40 @@
+ThisBuild / version := "0.1.0-SNAPSHOT"
+
+ThisBuild / scalaVersion := "3.5.0-RC1"
+
+ThisBuild / scalacOptions ++= Seq(
+  "-experimental",
+  "-new-syntax",
+  "-feature",
+  "-deprecation",
+  "-Wunused:imports",
+  "-Wimplausible-patterns",
+  "-Wsafe-init",
+  "-Yrequire-targetName",
+  "-Ycc-new",
+  "-Yexplicit-nulls",
+  "-Ycheck-all-patmat",
+  "-language:experimental.clauseInterleaving",
+  "-language:experimental.modularity",
+  "-language:experimental.genericNumberLiterals",
+  "-language:experimental.fewerBraces",
+  "-language:experimental.into",
+  "-language:experimental.erasedDefinitions",
+  "-language:experimental.saferExceptions",
+  "-language:experimental.namedTypeArguments",
+  "-language:implicitConversions"
+)
+
+lazy val core = (project in file("src/core"))
+  .settings(
+    name := "core",
+    libraryDependencies ++= Seq(
+        "dev.soundness" % "contingency-core" % "0.1.0",
+    ),
+    Compile / baseDirectory := baseDirectory.value,
+  )
+
+lazy val test = (project in file("src/test"))
+  .settings(
+    name := "test"
+  ).dependsOn(core)

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / version := "0.1.0-SNAPSHOT"
+ThisBuild / version := "0.3.0-SNAPSHOT"
 
 ThisBuild / scalaVersion := "3.5.0-RC1"
 


### PR DESCRIPTION
tests are done as a separate module, not a `core / Test` configuration
added .gitignore to cover created by sbt artifacts