### PR TITLE
ProductDerivation - constructWith method

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -469,18 +469,15 @@ Often your producer will return `F[_]`, like `Option` or `Either`, in this examp
 trait Parser[T]:
   def parse(input: String): Either[Exception, T]
 ```
-In this case there are a helper method called `constructWith`, which allows you to specify polymorphic `pure` and `bind`(aka flatMap) over your `F[_]` to help `constructWith` traverse parsing results:
+In this case there is a helper method called `constructWith`, which allows you to specify polymorphic `pure` and `bind`(aka flatMap) over your `F[_]` to help `constructWith` traverse producer typeclass results:
 ```scala
 object Parser extends ProductDerivation[Parser] {
   inline def join[DerivationType <: Product: ProductReflection]: Parser[DerivationType] = inputStr =>
     constructWith[DerivationType, Either](
-      [MonadicTypeIn, MonadicTypeOut] => a => a.flatMap(_),
+      [MonadicTypeIn, MonadicTypeOut] => _.flatMap,
       [MonadicType] => Right(_),
       [FieldType] => context =>
-        if index < inputArr.length then
-          context.parse(inputStr)
-        else 
-          Left(new Exception("parsing failed"))
+        context.parse(inputStr)
     )
 }
 ```

--- a/src/core/wisteria.ProductDerivationMethods.scala
+++ b/src/core/wisteria.ProductDerivationMethods.scala
@@ -68,6 +68,48 @@ trait ProductDerivationMethods[TypeclassType[_]]:
 
     flatMap[Tuple, DerivationType](resultingTuple)((v: Tuple) => pure(reflection.fromProduct(v.reverse)))
 
+  protected transparent inline def constructWithV2[DerivationType <: Product, F[_]]
+      (using reflection: ProductReflection[DerivationType], requirement: ContextRequirement)
+      (inline pure: [T] => T => F[T],
+       inline lambda: [FieldType] =>
+                          requirement.Optionality[TypeclassType[FieldType]] =>
+                              (typeclass: requirement.Optionality[TypeclassType[FieldType]],
+                               default:   Default[Optional[FieldType]],
+                               label:     Text,
+                               index:     Int & FieldIndex[FieldType],
+                               specify:   FieldType => F[FieldType]) ?=>
+                                  F[FieldType])
+          : F[DerivationType] =
+
+    type Fields = reflection.MirroredElemTypes
+    type Labels = reflection.MirroredElemLabels
+
+    val foldResult = fold[DerivationType, Fields, Labels, Either[F[DerivationType], Tuple]](Right(EmptyTuple), 0): accumulator =>
+        [FieldType] => context ?=> 
+          var specified: Option[FieldType] = None
+          // TODO: can this be a given?
+          // type Specify = FieldType => F[FieldType]
+          // given specify: Specify = value =>
+          implicit val specify: FieldType => F[FieldType] = value =>
+            specified = Some(value)
+            pure(value)
+
+          accumulator match
+            case Left(value) => Left(value)
+            case Right(accumulator) => 
+              val lambdaResult = lambda[FieldType](context)
+              specified match
+                case None => 
+                  Left(lambdaResult.asInstanceOf[F[DerivationType]])
+                case Some(result) =>
+                  specified = None
+                  Right(result *: accumulator)
+
+    foldResult match {
+      case Left(err) => err
+      case Right(value) => pure(reflection.fromProduct(value.reverse))
+    }
+
   protected transparent inline def contexts[DerivationType <: Product]
       (using reflection: ProductReflection[DerivationType], requirement: ContextRequirement)
       [ResultType]

--- a/src/core/wisteria.ProductDerivationMethods.scala
+++ b/src/core/wisteria.ProductDerivationMethods.scala
@@ -43,6 +43,73 @@ trait ProductDerivationMethods[TypeclassType[_]]:
         [FieldType] => context ?=> lambda[FieldType](context) *: accumulator
       .reverse
 
+  protected transparent inline def constructWith[DerivationType <: Product, F[_]]
+      (using reflection: ProductReflection[DerivationType], requirement: ContextRequirement)
+      (inline get: [FValueType] => F[FValueType] => FValueType,
+       inline shouldStop: [FValueType] => F[FValueType] => Boolean,
+       inline pure: [FValueType] => FValueType => F[FValueType],
+       inline lambda: [FieldType] =>
+                          requirement.Optionality[TypeclassType[FieldType]] =>
+                              (typeclass: requirement.Optionality[TypeclassType[FieldType]],
+                               default:   Default[Optional[FieldType]],
+                               label:     Text,
+                               index:     Int & FieldIndex[FieldType]) ?=>
+                                  F[FieldType])
+          : F[DerivationType] =
+
+    type Fields = reflection.MirroredElemTypes
+    type Labels = reflection.MirroredElemLabels
+
+    var errorCell: Option[F[DerivationType]] = None
+    val resultingTuple = fold[DerivationType, Fields, Labels, Tuple](EmptyTuple, 0): accumulator =>
+      [FieldType] => context ?=>
+        errorCell match
+          case None =>
+            val result = lambda[FieldType](context)
+            if shouldStop(result) then {
+              errorCell = Some(result.asInstanceOf[F[DerivationType]])
+              result *: EmptyTuple
+            } else {
+              get(result) *: accumulator
+            }
+          case Some(value) => accumulator
+    
+    errorCell match
+      case None => pure(reflection.fromProduct(resultingTuple))
+      case Some(error) => error
+
+  // WIP
+  protected transparent inline def constructWithV2[DerivationType <: Product, F[_]]
+      (using reflection: ProductReflection[DerivationType], requirement: ContextRequirement)
+      (inline pure: [FValueType] => FValueType => F[FValueType],
+       inline lambda: [FieldType] =>
+                          requirement.Optionality[TypeclassType[FieldType]] =>
+                              (typeclass: requirement.Optionality[TypeclassType[FieldType]],
+                               default:   Default[Optional[FieldType]],
+                               label:     Text,
+                               index:     Int & FieldIndex[FieldType],
+                               specify:   FieldType => FieldType) ?=>
+                                  FieldType | F[FieldType])
+          : F[DerivationType] =
+
+    type Fields = reflection.MirroredElemTypes
+    type Labels = reflection.MirroredElemLabels
+
+    val resultingTuple = foldWith[DerivationType, Fields, Labels, Tuple, F](EmptyTuple, 0): accumulator =>
+      [FieldType] => context ?=>
+        val result = lambda[FieldType](context)
+        println(result match
+          case e: F[FieldType] => false
+          case e: FieldType => true
+        )
+        result match
+          case v: F[FieldType] => v.asInstanceOf[F[Tuple]]
+          case result => result *: accumulator
+
+    resultingTuple match
+      case e: F[_] => e.asInstanceOf[F[DerivationType]]
+      case e: Tuple => pure(reflection.fromProduct(e))
+
   protected transparent inline def contexts[DerivationType <: Product]
       (using reflection: ProductReflection[DerivationType], requirement: ContextRequirement)
       [ResultType]
@@ -197,5 +264,57 @@ trait ProductDerivationMethods[TypeclassType[_]]:
             fold[DerivationType, moreFieldsType, moreLabelsType, ResultType]
              (accumulator2, index + 1)
              (lambda)
+
+  private transparent inline def foldWith
+    [DerivationType <: Product, FieldsType <: Tuple, LabelsType <: Tuple, ResultType, F[_]]
+    (using requirement: ContextRequirement)
+    (inline accumulator: ResultType, index: Int)
+    (inline lambda: ResultType =>
+                        [FieldType] =>
+                            requirement.Optionality[TypeclassType[FieldType]] =>
+                                (default:     Default[Optional[FieldType]],
+                                 label:       Text,
+                                 dereference: DerivationType => FieldType,
+                                 index:       Int & FieldIndex[FieldType],
+                                 specify:     ResultType => ResultType) ?=>
+                                    ResultType | F[ResultType])
+        : F[ResultType] | ResultType =
+
+  inline erasedValue[FieldsType] match
+    case _: EmptyTuple => accumulator
+
+    case _: (fieldType *: moreFieldsType) => inline erasedValue[LabelsType] match
+      case _: (labelType *: moreLabelsType) => inline valueOf[labelType].asMatchable match
+        case label: String =>
+          val typeclass = requirement.summon[TypeclassType[fieldType]]
+
+          val fieldIndex: Int & FieldIndex[fieldType] =
+            index.asInstanceOf[Int & FieldIndex[fieldType]]
+
+          val default = Default(Wisteria.default[DerivationType, fieldType](index))
+
+          val dereference: DerivationType => fieldType =
+            _.productElement(fieldIndex).asInstanceOf[fieldType]
+
+          var specified: Option[ResultType] = None
+          val specify: ResultType => ResultType = value =>
+            specified = Some(value)
+            value
+
+          val accumulator2 =
+            lambda(accumulator)[fieldType](typeclass)
+              (using default, label.tt, dereference, fieldIndex, specify)
+
+          specified match
+            case None => 
+              accumulator2
+            case Some(result) =>
+              specified = None
+              foldWith[DerivationType, moreFieldsType, moreLabelsType, ResultType, F]
+                (result, index + 1)
+                (lambda)
+          
+
+          
 
   inline def join[DerivationType <: Product: ProductReflection]: TypeclassType[DerivationType]

--- a/src/core/wisteria.SumDerivationMethods.scala
+++ b/src/core/wisteria.SumDerivationMethods.scala
@@ -62,6 +62,7 @@ trait SumDerivationMethods[TypeclassType[_]]:
     val size: Int = valueOf[Tuple.Size[reflection.MirroredElemTypes]]
     val variantLabel = label
 
+    // Here label comes from context of fold's predicate
     fold[DerivationType, Variants, Labels](size, 0, true)(label == variantLabel):
       [VariantType <: DerivationType] => context => lambda[VariantType](context)
     .vouch(using Unsafe)

--- a/src/test/tests.scala
+++ b/src/test/tests.scala
@@ -21,6 +21,8 @@ import rudiments.*
 import contingency.*
 import vacuous.*
 
+import scala.util.Try
+
 //object Month:
   //given Presentation[Month] = _.toString.tt
 
@@ -129,12 +131,13 @@ object Parser extends ProductDerivation[Parser] {
 
   inline def join[DerivationType <: Product: ProductReflection]: Parser[DerivationType] = inputStr =>
     IArray.from(inputStr.split(',')).pipe: inputArr =>
-      constructWith[DerivationType, Option](
-        [A, B] => _.flatMap,
+      constructWithV2[DerivationType, Option](
         [T] => Some(_),
         [FieldType] => context =>
           if index < inputArr.length then 
-            context.parse(inputArr(index)) 
+            context.parse(inputArr(index)) match
+              case None => None
+              case Some(value) => specify(value)
           else 
             None
       )
@@ -175,7 +178,9 @@ def main(): Unit =
   val human3 = "Person:george washington,1,yes".tt.read[Human]
   println(human1 === human2)
   println(human2 === human3)
-  // val human4 = "Broken:george washington,1,yes".tt.read[Human]
+  val human4 = Try("Broken:george washington,1,yes".tt.read[Human])
+  println(human4.isFailure)
+  println(human4.failed.get.getMessage())
 
   println("withContext:")
   val parserForTest = summon[Parser[ParserTestClass]]

--- a/src/test/tests.scala
+++ b/src/test/tests.scala
@@ -132,7 +132,7 @@ object Parser extends ProductDerivation[Parser] {
   inline def join[DerivationType <: Product: ProductReflection]: Parser[DerivationType] = inputStr =>
     IArray.from(inputStr.split(',')).pipe: inputArr =>
       constructWith[DerivationType, Option](
-        [MonadicTypeIn, MonadicTypeOut] => a => a.flatMap(_),
+        [MonadicTypeIn, MonadicTypeOut] => _.flatMap,
         [MonadicType] => Some(_),
         [FieldType] => context =>
           if index < inputArr.length then

--- a/src/test/tests.scala
+++ b/src/test/tests.scala
@@ -131,19 +131,18 @@ object Parser extends ProductDerivation[Parser] {
 
   inline def join[DerivationType <: Product: ProductReflection]: Parser[DerivationType] = inputStr =>
     IArray.from(inputStr.split(',')).pipe: inputArr =>
-      constructWithV2[DerivationType, Option](
-        [T] => Some(_),
+      constructWith[DerivationType, Option](
+        [MonadicTypeIn, MonadicTypeOut] => a => a.flatMap(_),
+        [MonadicType] => Some(_),
         [FieldType] => context =>
-          if index < inputArr.length then 
-            context.parse(inputArr(index)) match
-              case None => None
-              case Some(value) => specify(value)
+          if index < inputArr.length then
+            context.parse(inputArr(index))
           else 
             None
       )
 }
 
-case class ParserTestClass(intValue: Int, booleanValue: Boolean)
+case class ParserTestCaseClass(intValue: Int, booleanValue: Boolean)
 
 @main
 def main(): Unit =
@@ -183,9 +182,8 @@ def main(): Unit =
   println(human4.failed.get.getMessage())
 
   println("withContext:")
-  val parserForTest = summon[Parser[ParserTestClass]]
+  val parserForTest = summon[Parser[ParserTestCaseClass]]
   val successfulParse = parserForTest.parse("120,false")
-  println(successfulParse.get)
   println(successfulParse.exists(_.intValue == 120))
   println(successfulParse.exists(_.booleanValue == false))
   println(parserForTest.parse("error").isEmpty)


### PR DESCRIPTION
`constructWith` using that takes `bind` and `pure` polymorphic functions in order to be able to traverse F[_] as a producer result
